### PR TITLE
Use computed offset passed in DateTime constructor

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -447,7 +447,9 @@ export default class DateTime {
       if (unchanged) {
         [c, o] = [config.old.c, config.old.o];
       } else {
-        const ot = zone.offset(this.ts);
+        // If an offset has been passed and we have not been called from
+        // clone(), we can trust it and avoid the offset calculation.
+        const ot = config.o && !config.old ? config.o : zone.offset(this.ts);
         c = tsToObj(this.ts, ot);
         invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
         c = invalid ? null : c;


### PR DESCRIPTION
All calls to the datetime constructor that pass an offset (o), have just computed that offset (quickDT, fromObject) except for clone(). Clone passes an "old" option to determine whether previous offset can be reused. If we have config.o, but config.old is not set, then we can use o without computing it.

This saves an expensive call to zone.offset that duplicates work that was done immediately prior.