### PR TITLE
Add option, forceHackyOffset, to force use of hackyOffset

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -9,7 +9,8 @@ let now = () => Date.now(),
   defaultLocale = null,
   defaultNumberingSystem = null,
   defaultOutputCalendar = null,
-  throwOnInvalid;
+  throwOnInvalid,
+  forceHackyOffset = false;
 
 /**
  * Settings contains static getters and setters that control Luxon's overall behavior. Luxon is a simple library with few options, but the ones it does have live here.
@@ -114,6 +115,23 @@ export default class Settings {
    */
   static set throwOnInvalid(t) {
     throwOnInvalid = t;
+  }
+
+  /**
+   * Get whether Luxon will always use hackyOffset for calculation time zone
+   * offsets.
+   */
+  static get forceHackyOffset() {
+    return forceHackyOffset;
+  }
+
+  /**
+   * Set whether Luxon will always use hackyOffset for calculating time zone
+   * offsets. This can be much faster than the safer/cleaner partsOffset based
+   * on formatToParts.
+   */
+  static set forceHackyOffset(f) {
+    forceHackyOffset = f;
   }
 
   /**

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -1,5 +1,6 @@
 import { formatOffset, parseZoneInfo, isUndefined, objToLocalTS } from "../impl/util.js";
 import Zone from "../zone.js";
+import Settings from "../settings.js";
 
 let dtfCache = {};
 function makeDTF(zone) {
@@ -33,7 +34,7 @@ function hackyOffset(dtf, date) {
   const formatted = dtf.format(date).replace(/\u200E/g, ""),
     parsed = /(\d+)\/(\d+)\/(\d+) (AD|BC),? (\d+):(\d+):(\d+)/.exec(formatted),
     [, fMonth, fDay, fYear, fadOrBc, fHour, fMinute, fSecond] = parsed;
-  return [fYear, fMonth, fDay, fadOrBc, fHour, fMinute, fSecond];
+  return [+fYear, +fMonth, +fDay, fadOrBc, +fHour, +fMinute, +fSecond];
 }
 
 function partsOffset(dtf, date) {
@@ -150,9 +151,10 @@ export default class IANAZone extends Zone {
     if (isNaN(date)) return NaN;
 
     const dtf = makeDTF(this.name);
-    let [year, month, day, adOrBc, hour, minute, second] = dtf.formatToParts
-      ? partsOffset(dtf, date)
-      : hackyOffset(dtf, date);
+    let [year, month, day, adOrBc, hour, minute, second] =
+      dtf.formatToParts && !Settings.forceHackyOffset
+        ? partsOffset(dtf, date)
+        : hackyOffset(dtf, date);
 
     if (adOrBc === "BC") {
       year = -Math.abs(year) + 1;


### PR DESCRIPTION
The time zone offset of a date can be computed on platforms that support it (anything that's not super ancient) by using
Intl.DateTimeFormat.formatToParts with en-US to output an array of the date components. For legacy reasons, you can also generate a date string using Intl.DateTimeFormat.format which can be parsed into an array using regexes. The string/regex approach (hackyOffset) is way faster (2-4x), but much more susceptible to weird client configurations.

This adds an option to use hackyOffset. I tested it by defaulting the setting to true and running the test suite.