### PR TITLE
Use hackyOffset if it parses date strings in the expected format

### DIFF
--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -29,11 +29,21 @@ const typeToPos = {
   second: 6,
 };
 
+function offsetComponentsFromDtf(dtf, date) {
+  if (IANAZone.hackyOffsetParsesCorrectly()) {
+    return hackyOffset(dtf, date);
+  } else if (dtf.formatToParts) {
+    return partsOffset(dtf, date);
+  } else {
+    throw new Error("Unable to compute time zone offset using Intl.DateTimeFormat");
+  }
+}
+
 function hackyOffset(dtf, date) {
   const formatted = dtf.format(date).replace(/\u200E/g, ""),
     parsed = /(\d+)\/(\d+)\/(\d+) (AD|BC),? (\d+):(\d+):(\d+)/.exec(formatted),
     [, fMonth, fDay, fYear, fadOrBc, fHour, fMinute, fSecond] = parsed;
-  return [fYear, fMonth, fDay, fadOrBc, fHour, fMinute, fSecond];
+  return [+fYear, +fMonth, +fDay, fadOrBc, +fHour, +fMinute, +fSecond];
 }
 
 function partsOffset(dtf, date) {
@@ -51,6 +61,8 @@ function partsOffset(dtf, date) {
   }
   return filled;
 }
+
+let hackyOffsetParsesCorrectly = undefined;
 
 let ianaZoneCache = {};
 /**
@@ -76,6 +88,45 @@ export default class IANAZone extends Zone {
   static resetCache() {
     ianaZoneCache = {};
     dtfCache = {};
+    hackyOffsetParsesCorrectly = undefined;
+  }
+
+  /**
+   * Get a DTF instance from the cache. Should only be used for testing.
+   *
+   * @access private
+   */
+  static getDtf(zone) {
+    return makeDTF(zone);
+  }
+
+  /**
+   * Returns whether hackyOffset works correctly for a known date. If it does,
+   * we can use hackyOffset which is faster.
+   * @returns {boolean}
+   */
+  static hackyOffsetParsesCorrectly() {
+    if (hackyOffsetParsesCorrectly === undefined) {
+      const dtf = makeDTF("UTC");
+      try {
+        const [year, month, day, adOrBc, hour, minute, second] = hackyOffset(
+          dtf,
+          // arbitrary date
+          new Date(Date.UTC(1969, 11, 31, 15, 45, 55))
+        );
+        hackyOffsetParsesCorrectly =
+          year === 1969 &&
+          month === 12 &&
+          day === 31 &&
+          adOrBc === "AD" &&
+          hour === 15 &&
+          minute === 45 &&
+          second === 55;
+      } catch {
+        hackyOffsetParsesCorrectly = false;
+      }
+    }
+    return hackyOffsetParsesCorrectly;
   }
 
   /**
@@ -150,9 +201,7 @@ export default class IANAZone extends Zone {
     if (isNaN(date)) return NaN;
 
     const dtf = makeDTF(this.name);
-    let [year, month, day, adOrBc, hour, minute, second] = dtf.formatToParts
-      ? partsOffset(dtf, date)
-      : hackyOffset(dtf, date);
+    let [year, month, day, adOrBc, hour, minute, second] = offsetComponentsFromDtf(dtf, date);
 
     if (adOrBc === "BC") {
       year = -Math.abs(year) + 1;

--- a/test/zones/IANA.test.js
+++ b/test/zones/IANA.test.js
@@ -1,4 +1,4 @@
-/* global test expect */
+/* global test expect jest */
 import { FixedOffsetZone, IANAZone } from "../../src/luxon";
 
 test("IANAZone.create returns a singleton per zone name", () => {
@@ -14,6 +14,41 @@ test("IANAZone.create returns a singleton per zone name", () => {
 test("IANAZone.create should return IANAZone instance", () => {
   const result = IANAZone.create("America/Cancun");
   expect(result).toBeInstanceOf(IANAZone);
+});
+
+describe("IANAZone.hackyOffsetParsesCorrectly", () => {
+  beforeEach(() => {
+    IANAZone.resetCache();
+  });
+
+  test("is true", () => {
+    expect(IANAZone.hackyOffsetParsesCorrectly()).toBe(true);
+  });
+
+  test("is true when the date format is as expected", () => {
+    jest
+      .spyOn(IANAZone.getDtf("UTC"), "format")
+      .mockImplementation(() => "12/31/1969 AD, 15:45:55");
+    expect(IANAZone.hackyOffsetParsesCorrectly()).toBe(true);
+  });
+
+  test("is false when the date format swaps the month and day", () => {
+    jest
+      .spyOn(IANAZone.getDtf("UTC"), "format")
+      .mockImplementation(() => "31/12/1969 AD, 15:45:55");
+    expect(IANAZone.hackyOffsetParsesCorrectly()).toBe(false);
+  });
+
+  test("is false when the date format uses different delimiters", () => {
+    jest
+      .spyOn(IANAZone.getDtf("UTC"), "format")
+      .mockImplementation(() => "12-31-1969 AD, 15:45:55");
+    expect(IANAZone.hackyOffsetParsesCorrectly()).toBe(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 });
 
 test("IANAZone.isValidSpecifier", () => {


### PR DESCRIPTION
The time zone offset of a date can be computed on platforms that support it (anything that's not super ancient) by using
Intl.DateTimeFormat.formatToParts with en-US to output an array of the date components. For legacy reasons, you can also generate a date string using Intl.DateTimeFormat.format which can be parsed into an array using regexes. The string/regex approach (hackyOffset) is way faster (2-4x), but much more susceptible to weird client configurations.

This detects whether hackyOffset is able to parse a known date correctly, and uses it if it does.

Take 2 of https://github.com/makenotion/luxon/pull/3 . This should get around issues like https://github.com/moment/luxon/issues/849 while allowing us to use hackyOffset on both client and server in most cases. I expose `IANAZone.hackyOffsetParsesCorrectly` so that we can log when it is false.