### PR TITLE
Configure package to enable build/install when used as a git dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "luxon",
       "version": "3.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "format-check": "prettier --check 'src/**/*.js' 'test/**/*.js' 'benchmarks/*.js'",
     "benchmark": "babel-node benchmarks/index.js",
     "codecov": "codecov",
-    "prepack": "babel-node tasks/buildAll.js",
-    "prepare": "husky install"
+    "postinstall": "husky install || exit 0",
+    "prepare": "babel-node tasks/buildAll.js"
   },
   "lint-staged": {
     "*.{js,json}": [


### PR DESCRIPTION
Run buildAll in prepare, move husky install to postinstall

Husky adds git hooks into the repo. We want the dev experience of

    $ git clone remote/luxon
    $ npm install # installs husky hooks
    $ ...develop develop develop...
    $ git commit
    _lint runs, everything works_

We also want to build luxon when we call npm pack or npm publish.

We also want to build luxon when it is installed somewhere else as a git dependency
(https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies)

Git dependencies work by running `npm install` from GitFetcher and then depend on DirFetcher running `npm prepare` (but only prepare, not prepack or postpack)

This change moves `husky install` to postinstall (which will, unfortunately, still pointlessly run when we install luxon as a git dependency). It moves the buildAll to prepare from prepack so that the build happens when installed as a git dependency. This should preserve existing behavior while enabling installation from git.

When installing from git and/or in CI environments, the husky command is sometimes not available in postinstall or is available but bails out when not run in the context of a git repo.