### PR TITLE
Cache Intl.DateTimeFormat.resolvedOptions in supportsFastNumbers and isEnglish

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -45,6 +45,13 @@ function runDateTimeSuite() {
         dt.toFormat("T");
         Settings.resetCaches();
       })
+      .add("DateTime#format in german", () => {
+        dt.setLocale("de-De").toFormat("d. LLL. HH:mm");
+      })
+      .add("DateTime#format in german and no-cache", () => {
+        dt.setLocale("de-De").toFormat("d. LLL. HH:mm");
+        Settings.resetCaches();
+      })
       .add("DateTime#add", () => {
         dt.plus({ milliseconds: 3434 });
       })

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -61,6 +61,14 @@ function systemLocale() {
   }
 }
 
+let intlResolvedOptionsCache = {};
+function getCachedIntResolvedOptions(locString) {
+  if (!intlResolvedOptionsCache[locString]) {
+    intlResolvedOptionsCache[locString] = new Intl.DateTimeFormat(locString).resolvedOptions();
+  }
+  return intlResolvedOptionsCache[locString];
+}
+
 function parseLocaleString(localeStr) {
   // I really want to avoid writing a BCP 47 parser
   // see, e.g. https://github.com/wooorm/bcp-47
@@ -143,7 +151,7 @@ function supportsFastNumbers(loc) {
       loc.numberingSystem === "latn" ||
       !loc.locale ||
       loc.locale.startsWith("en") ||
-      new Intl.DateTimeFormat(loc.intl).resolvedOptions().numberingSystem === "latn"
+      getCachedIntResolvedOptions(loc.locale).numberingSystem === "latn"
     );
   }
 }
@@ -272,7 +280,6 @@ class PolyRelFormatter {
 /**
  * @private
  */
-
 export default class Locale {
   static fromOpts(opts) {
     return Locale.create(opts.locale, opts.numberingSystem, opts.outputCalendar, opts.defaultToEN);
@@ -292,6 +299,7 @@ export default class Locale {
     intlDTCache = {};
     intlNumCache = {};
     intlRelCache = {};
+    intlResolvedOptionsCache = {};
   }
 
   static fromObject({ locale, numberingSystem, outputCalendar } = {}) {
@@ -444,7 +452,7 @@ export default class Locale {
     return (
       this.locale === "en" ||
       this.locale.toLowerCase() === "en-us" ||
-      new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us")
+      getCachedIntResolvedOptions(this.intl).locale.startsWith("en-us")
     );
   }
 


### PR DESCRIPTION
Cherry-picked from upstream https://github.com/moment/luxon/pull/1642

This fixes a major performance issue with formatting in non-English locales. See the upstream PR, and https://github.com/makenotion/notion-next/pull/122807 for more details and benchmarks