### PR TITLE
Pin github workflows to a commit hash instead of version tag for security purpose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
This PR pins Github workflows to a specific commit hash instead of version tag, for security purpose.

By pinning Github workflows to a specific commit hash, we should be able to restrict deployment of potentially compromised Github actions in the future. If you have any questions, please reach out to #sec-team-appsec.

Note: If you ever need to manually look up the commit hash for a given action version (tag), you can run:

    git ls-remote https://github.com/<owner>/<repo>.git <tag>

Replace `<owner>`, `<repo>`, and `<tag>` with the appropriate values (for example, `actions/checkout` and `v3`). The output will show the commit SHA corresponding to the tag. Use that SHA in your workflow file, e.g.:

    uses: actions/checkout@<sha> # <tag version>
